### PR TITLE
Increasing security for symetric key encodings

### DIFF
--- a/addFriend.js
+++ b/addFriend.js
@@ -22,7 +22,7 @@ function addFriend() {
       var encaps = NTRUEncapsulate(publicKeyOfFriend);
       var plainkey = encaps[0];
       var symkeyforfriend = encaps[1];
-      var symkeyforme = AESencrypt(plainkey, decryptionkey);
+      var symkeyforme = AESencryptCBC_arr(plainkey, decryptionkey);
 
       $.post("addFriend.php", {
         username: inputEmail, 

--- a/aes.js
+++ b/aes.js
@@ -24,3 +24,42 @@ function AESdecrypt(ciphertext, key) {
   var decryptedBytes = aesCtr.decrypt(encryptedBytes);
   return aesjs.util.convertBytesToString(decryptedBytes);
 }
+
+function AESencryptCTR(text, key, arrNonce) {
+  if(typeof text === 'string')
+    text = aesjs.util.convertStringToBytes(text);
+  var shiftedNonce = [0, 0, 0, 0, 0, 0, 0, 0 ].concat(arrNonce);
+  var aesCtr = new aesjs.ModeOfOperation.ctr(key, new aesjs.Counter(shiftedNonce));
+  var encryptedBytes = aesCtr.encrypt(text);
+  return btoa(String.fromCharCode.apply(null,encryptedBytes));
+}
+
+function AESdecryptCTR(ciphertext, key, hexNonce) {
+  var encryptedBytes = atob(ciphertext).split("").map(function(c) { return c.charCodeAt(0); });
+  var shiftedNonce = [0, 0, 0, 0, 0, 0, 0, 0 ].concat(HexString_2_ByteArray(hexNonce));
+  var aesCtr = new aesjs.ModeOfOperation.ctr(key, new aesjs.Counter(shiftedNonce));
+  var decryptedBytes = aesCtr.decrypt(encryptedBytes);
+  return aesjs.util.convertBytesToString(decryptedBytes);
+}
+
+/* ------- utils ------- */
+function HexString_2_ByteArray(hexString) {
+  var result = [];
+  for (var i = 0; i < hexString.length; i += 2) {
+    result.push(parseInt(hexString.substr(i, 2), 16));
+  }
+  return result;
+}
+
+function ByteArray_2_HexString(arr) {
+  var result = "";
+  for (i in arr) {
+    var str = arr[i].toString(16);
+    str = str.length == 0 ? "00" :
+    str.length == 1 ? "0" + str :
+    str.length == 2 ? str :
+    str.substring(str.length-2, str.length);
+    result += str;
+  }
+  return result;
+}

--- a/aes.js
+++ b/aes.js
@@ -42,6 +42,24 @@ function AESdecryptCTR(ciphertext, key, hexNonce) {
   return aesjs.util.convertBytesToString(decryptedBytes);
 }
 
+function AESencryptCBC_txt(text, key, iniVector) {
+  text = aesjs.util.convertStringToBytes(text);
+  while (text.length % 16 !== 0) //insert null padding
+    text.push(0);
+  var aesCBC = new aesjs.ModeOfOperation.cbc(key, iniVector);
+  var encryptedBytes = aesCBC.encrypt(text);
+  return btoa(String.fromCharCode.apply(null,encryptedBytes));
+}
+
+function AESdecryptCBC_txt(ciphertext, key, iniVector) {
+  var encryptedBytes = atob(ciphertext).split("").map(function(c) { return c.charCodeAt(0); });
+  var aesCBC = new aesjs.ModeOfOperation.cbc(key, iniVector);
+  var decryptedBytes = aesCBC.decrypt(encryptedBytes);
+  while (decryptedBytes[decryptedBytes.length-1] == 0) //remove null padding
+    decryptedBytes.pop();
+  return aesjs.util.convertBytesToString(decryptedBytes);
+}
+
 /* ------- utils ------- */
 function HexString_2_ByteArray(hexString) {
   var result = [];

--- a/aes.js
+++ b/aes.js
@@ -9,21 +9,6 @@
  * Given the uniqueness of the project (no other student had, have or will have the same project) we have published our code on GitHub with the permission of our professors.
  * Students’ regulation of Eötvös Loránd University (ELTE Regulations Vol. II. 74/C. § ) states that as long as a student presents another student’s work - or at least the significant part of it - as his/her own performance, it will count as a disciplinary fault. The most serious consequence of a disciplinary fault can be dismissal of the student from the University.
  */
- 
-function AESencrypt(text, key) {
-  if(typeof text === 'string')
-    text = aesjs.util.convertStringToBytes(text);
-  var aesCtr = new aesjs.ModeOfOperation.ctr(key, new aesjs.Counter(5));
-  var encryptedBytes = aesCtr.encrypt(text);
-  return encodeURIComponent(btoa(String.fromCharCode.apply(null,encryptedBytes)));
-}
-
-function AESdecrypt(ciphertext, key) {
-  var encryptedBytes = atob(decodeURIComponent(ciphertext)).split("").map(function(c) { return c.charCodeAt(0); });
-  var aesCtr = new aesjs.ModeOfOperation.ctr(key, new aesjs.Counter(5));
-  var decryptedBytes = aesCtr.decrypt(encryptedBytes);
-  return aesjs.util.convertBytesToString(decryptedBytes);
-}
 
 function AESencryptCTR(text, key, arrNonce) {
   if(typeof text === 'string')
@@ -58,6 +43,19 @@ function AESdecryptCBC_txt(ciphertext, key, iniVector) {
   while (decryptedBytes[decryptedBytes.length-1] == 0) //remove null padding
     decryptedBytes.pop();
   return aesjs.util.convertBytesToString(decryptedBytes);
+}
+
+function AESencryptCBC_arr(arr, key, iniVector) {
+  var aesCBC = new aesjs.ModeOfOperation.cbc(key, iniVector);
+  var encryptedBytes = aesCBC.encrypt(arr);
+  return btoa(String.fromCharCode.apply(null,encryptedBytes));
+}
+
+function AESdecryptCBC_arr(ciphertext, key, iniVector) {
+  var encryptedBytes = atob(ciphertext).split("").map(function(c) { return c.charCodeAt(0); });
+  var aesCBC = new aesjs.ModeOfOperation.cbc(key, iniVector);
+  var decryptedBytes = aesCBC.decrypt(encryptedBytes);
+  return decryptedBytes;
 }
 
 /* ------- utils ------- */

--- a/database_setup.sql
+++ b/database_setup.sql
@@ -60,6 +60,7 @@ CREATE TABLE `messages` (
   `user1` int(11) NOT NULL,
   `user2` int(11) NOT NULL,
   `messages` text COLLATE latin2_hungarian_ci NOT NULL,
+  `nonce` binary(16) NOT NULL,
   `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=latin2 COLLATE=latin2_hungarian_ci;
 

--- a/getMessages.php
+++ b/getMessages.php
@@ -27,19 +27,19 @@ if(!(substr(loginhelper($conn, $_POST['username'], $_POST['password']),0,1) === 
   
 $userId = getUserId($conn, $_POST['username']);
 // prepare, bind and execute
-$stmt = $conn->prepare("SELECT messages, user1 FROM messages WHERE (messages.user1 = ? AND  messages.user2 = ?) OR (messages.user2 = ? AND  messages.user1 = ?) ORDER BY time ASC"); 
+$stmt = $conn->prepare("SELECT messages, user1, nonce FROM messages WHERE (messages.user1 = ? AND  messages.user2 = ?) OR (messages.user2 = ? AND  messages.user1 = ?) ORDER BY time ASC");
 $stmt->bind_param("iiii", $userId, $_POST['user2Id'], $userId, $_POST['user2Id']);
 $stmt->execute();
 if ($stmt->errno)
   die("Error during the execution of the SQL query");
 
 //get the result
-$stmt->bind_result($message, $user1);
+$stmt->bind_result($message, $user1, $nonce);
 
 while($stmt->fetch()) {
   if($user1 === $userId)
-    echo "1" . $message . "\n";
+    echo "1" . $nonce . ";" . $message . "\n";
   else
-    echo "0" . $message . "\n";
+    echo "0" . $nonce . ";" . $message . "\n";;
   }
 ?>

--- a/handleFriendRequests.js
+++ b/handleFriendRequests.js
@@ -19,7 +19,7 @@ function handleFriendRequests() {
       //NTRU decrypt
       var plainSymKey = NTRUDecapsulate(requests[i][2], privatekey);
       //AES encrypt the symkey
-      var AESSymKey = AESencrypt(plainSymKey, decryptionkey);
+      var AESSymKey = AESencryptCBC_arr(plainSymKey, decryptionkey);
       //send the symkey back, delete the requests
       $.post("acceptRequest.php", { username: inputEmail, password: authenticationkey, friendId: requests[i][1], symkeyforme: AESSymKey },
       function(data, status){

--- a/ntru.js
+++ b/ntru.js
@@ -77,8 +77,7 @@ function generateNTRUKeys(deckey, callback) {
     w.terminate();
     var privatekey = event.data[0];
     var publickey = event.data[1];
-    var encryptedPrivatekey = AESencrypt(privatekey, deckey); //encrypt the privatekey
-    callback([encryptedPrivatekey, publickey]);
+    callback([privatekey, publickey]);
   };
 }
 

--- a/ntrutest.html
+++ b/ntrutest.html
@@ -161,8 +161,8 @@ function prepare() {
   logToScreen("<h2>Prepare started</h2>");
   var decryptionkey = secureRandom(16); //originally the first 16 character of the hash of the password, but it will do here
   generateNTRUKeys(decryptionkey, function(keys) {
-    var encprivate = keys[0];
-    privatekey = AESdecrypt(encprivate, decryptionkey)
+    privatekey = keys[0];
+    var encprivate = AESencryptCBC_txt(privatekey, decryptionkey)
     publickey = keys[1]; 
     logToScreen("<b>The following keys have been generated:</b>");
     logToScreen("<b>Decryptionkey: </b>" + decryptionkey.toString());

--- a/postq.js
+++ b/postq.js
@@ -25,8 +25,10 @@ function send() {
   var msgWithId = msgId.toString() + ";" + msg;
   $('#newmsg').val(''); //cleare the message box
   
-  var encMsg = AESencrypt(msgWithId,msgSymKey);
-  $.post("sendMsg.php", { username: inputEmail, password: authenticationkey,  user2Id: user2Id, msg: encMsg }, 
+  var nonce = secureRandom(8);
+  var encMsg = AESencryptCTR(msgWithId,msgSymKey,nonce);
+  var hexNonce = ByteArray_2_HexString(nonce);
+  $.post("sendMsg.php", { username: inputEmail, password: authenticationkey,  user2Id: user2Id, msg: encMsg, nonce: hexNonce}, 
   function(data, status){
     if(data == 1) { //if success, display message
       $("#alertMessages").hide(); //hide the alert

--- a/sendMsg.php
+++ b/sendMsg.php
@@ -18,7 +18,7 @@
 //            msg:      iExmLmGEgXVDPfGjI+=
 require_once("helpers.php");
 require_once("sqlconnect.php");
-if(!$_POST['username'] || !$_POST['password'] || !$_POST['user2Id'] || !$_POST['msg'])
+if(!$_POST['username'] || !$_POST['password'] || !$_POST['user2Id'] || !$_POST['msg'] || !$_POST['nonce'])
   die("Error - one of the parameters is not set.");
 
 //check password
@@ -27,8 +27,8 @@ if(!(substr(loginhelper($conn, $_POST['username'], $_POST['password']),0,1) === 
 
 $userId = getUserId($conn, $_POST['username']);
 // prepare, bind and execute
-$stmt = $conn->prepare("INSERT INTO messages (user1, user2, messages) VALUES (?, ?, ?)"); 
-$stmt->bind_param("iis", $userId, $_POST['user2Id'], $_POST['msg']);
+$stmt = $conn->prepare("INSERT INTO messages (user1, user2, messages, nonce) VALUES (?, ?, ?, ?)"); 
+$stmt->bind_param("iiss", $userId, $_POST['user2Id'], $_POST['msg'], $_POST['nonce']);
 $stmt->execute();
 if ($stmt->errno)
   die("Error during the execution of the SQL query");

--- a/show.js
+++ b/show.js
@@ -47,8 +47,9 @@ function showMessages(username, userid, symkey) {
     for(var i=0; i<messages.length; i++) {
       if(messages[i] != "") {
         var fromTo = messages[i].substring(0,1);
-        var idAndMsg = messages[i].substring(1);
-        var decIdAndMsg = AESdecrypt(idAndMsg, msgSymKey);
+        var msgNonce = messages[i].substring(1, messages[i].indexOf(";"));
+        var idAndMsg = messages[i].substring(messages[i].indexOf(";")+1);
+        var decIdAndMsg = AESdecryptCTR(idAndMsg, msgSymKey, msgNonce);
         var decIdAndMsgA = decIdAndMsg.split(";");
         var msg = decIdAndMsgA[1];
         var msgIdi = parseInt(decIdAndMsgA[0]);

--- a/show.js
+++ b/show.js
@@ -33,10 +33,7 @@ function showMessages(username, userid, symkey) {
   msgIduser2 = 0;
 
   //decrypt symmetric key
-  var encryptedBytes = atob(symkey).split("").map(function(c) { return c.charCodeAt(0); });
-  var aesCtr = new aesjs.ModeOfOperation.ctr(decryptionkey, new aesjs.Counter(5));
-  msgSymKey = aesCtr.decrypt(encryptedBytes);
-  msgSymKey = msgSymKey.slice(0,32);
+  msgSymKey = AESdecryptCBC_arr(symkey, decryptionkey);
  
   $.post("getMessages.php", { username: inputEmail, password: authenticationkey, user2Id: user2Id },
 

--- a/signalMsg.js
+++ b/signalMsg.js
@@ -2,8 +2,11 @@
 // send a signaling message identified by id=0 and extra date paramter
 function sendSignal(msg){
   var msgWithId = "0;&" + JSON.stringify(msg)+"&"+ Date.now();
-  var encMsg = AESencrypt(msgWithId,msgSymKey); //AESencrypt is not defined
-    $.get("sendMsg.php?username=" + inputEmail + "&password=" + authenticationkey + "&user2Id=" + user2Id + "&msg=" + encMsg,
+  var nonce = secureRandom(8);
+  var encMsg = AESencryptCTR(msgWithId,msgSymKey,nonce);
+  var hexNonce = ByteArray_2_HexString(nonce);
+
+  $.post("sendMsg.php", { username: inputEmail, password: authenticationkey,  user2Id: user2Id, msg: encMsg, nonce: hexNonce},
     function(data, status){
       if(data == 1) {
         //console.log(`message sent = ${msgWithId}`);

--- a/signin.js
+++ b/signin.js
@@ -45,7 +45,7 @@ function signin_from_localStorage(){
       if(data.substring(0,1) == '1') { //successfull login
         $('#signin').hide();
         $('#main').show();
-        privatekey = AESdecrypt(data.substr(1), decryptionkey); //login.php returns '1'.privatekey_aes
+        privatekey = AESdecryptCBC_txt(data.substr(1), decryptionkey); //login.php returns '1'.privatekey_aes
         handleFriendRequests();
         generateMenu();
       } else {
@@ -87,7 +87,7 @@ function signin() {
           if(data.substring(0,1) == '1') { //successfull login
             $('#signin').hide();
             $('#main').show();
-            privatekey = AESdecrypt(data.substr(1), decryptionkey); //login.php returns '1'.privatekey_aes
+            privatekey = AESdecryptCBC_txt(data.substr(1), decryptionkey); //login.php returns '1'.privatekey_aes
             handleFriendRequests();
             generateMenu();
             if ($('#rememberMe').is(":checked")) { //Option to remeber user saving keys
@@ -119,12 +119,13 @@ function register() {
     } else if (hash) {
       decryptionkey = hash.slice(0,16);
       var authenticationkey = btoa(String.fromCharCode.apply(null,hash.slice(16,32)));
-      keys = generateNTRUKeys(decryptionkey, function(keys){
+      generateNTRUKeys(decryptionkey, function(keys){
         updateInterface(0.9);
+        var enc_privatekey= AESencryptCBC_txt(keys[0],decryptionkey);
         $.post("register.php", {
           username: inputEmail,
           password: authenticationkey,
-          privatekey: keys[0],
+          privatekey: enc_privatekey,
           publickey: btoa(keys[1])
         },
         function(data, status){


### PR DESCRIPTION
Here is a PR to clear issue #6 

For messages encoding, the symkey is used many times, and the messages can be short and the same, so I decided to add 64-bit nonce to the DB and continue to use CTR mode. Information about exact message lenght still can be extracted, but not useful.

For private key encoding, the string has low randomness (i.e: x^738-x^734+...), is long (about 4 thousand chars) but decryptionkey is used only once in this type of message. CBC is enough even without initialization vector.

For symkey encoding, it has high randomness, is short (32 bytes, or exactly 2 blocks) and used some times. CBC is enough even without initialization vector, because chances are very low that the first 16 bytes are equal another symkey.

I also moved privatekey encoding from nrtu.js to signin.js, for better understand. I needed to update ntrutest.html to reflect this change.

Last, I updated signalMsg.js to reflect encryption mode changes and also fixed video chat because other commit (7787c9d8e83af13083b09c46304f4e8fb2af584a in #3 ) broke it. Unfortunately I can not check if it is fully working (no webcam). @f-viktor could check?