### PR TITLE
Added negotiation for friend requests and changing symkeys

### DIFF
--- a/acceptChangeSymkey.php
+++ b/acceptChangeSymkey.php
@@ -1,0 +1,50 @@
+<?php
+
+//Usage: acceptRequest.php
+//   username=test@test.com
+//   password=iExmLmGEgXVDPfGjI%2Fk5Iw%3D%3D
+//   friendId=5
+//   symkeyforme=iExmLmGEgXVDPfGw%3D%3D
+
+require_once("helpers.php");
+require_once("sqlconnect.php");
+
+if(!$_POST['username'] || !$_POST['password'] || !$_POST['friendId'] || !$_POST['symkeyforme'])
+  die("Error - one of the parameters is not set.");
+
+//check password
+if(!(substr(loginhelper($conn, $_POST['username'], $_POST['password']),0,1) === "1")) //loginhelper() needs to return with 1... for successfull login
+  die("Authentication failed");
+
+$userId = getUserId($conn, $_POST['username']);
+//delete request
+$stmt = $conn->prepare("DELETE FROM symkeyrequests WHERE useridTO = ? AND useridFROM = ?");
+$stmt->bind_param("ii", $userId, $_POST['friendId']);
+$stmt->execute();
+if($stmt->errno)
+  die("Error during the execution of the SQL query - 3");
+
+if($conn->affected_rows !== 1)
+  die("Error - not existing symkey request");
+
+//delete older messages
+$stmt = $conn->prepare("DELETE FROM messages WHERE user1 = ? AND user2 = ?");
+$stmt->bind_param("ii", $userId, $friendId);
+$stmt->execute();
+if($stmt->errno)
+  die("Error during the execution of the SQL query - 2");
+
+
+//add my new symkey
+$stmt = $conn->prepare("UPDATE symkeys SET symkey = ? WHERE  user1 = ? AND user2  = ?");
+$stmt->bind_param("sii", $_POST['symkeyforme'], $userId, $_POST['friendId'] );
+$stmt->execute();
+if($stmt->errno) {
+  die("Error during the execution of the SQL query - 1");
+}
+
+echo "1";
+
+$stmt->close();
+$conn->close();
+?>

--- a/acceptChangeSymkey.php
+++ b/acceptChangeSymkey.php
@@ -1,6 +1,6 @@
 <?php
 
-//Usage: acceptRequest.php
+//Usage: acceptChangeSymkey.php
 //   username=test@test.com
 //   password=iExmLmGEgXVDPfGjI%2Fk5Iw%3D%3D
 //   friendId=5

--- a/acceptRequest.php
+++ b/acceptRequest.php
@@ -23,7 +23,7 @@ if(!(substr(loginhelper($conn, $_POST['username'], $_POST['password']),0,1) === 
 
 $userId = getUserId($conn, $_POST['username']);
 //delete request
-$stmt = $conn->prepare("DELETE FROM friendrequests WHERE user1 = ? AND user2 = ?");
+$stmt = $conn->prepare("DELETE FROM friendrequests WHERE useridTO = ? AND useridFROM = ?");
 $stmt->bind_param("ii", $userId, $_POST['friendId']);
 $stmt->execute();
 if ($stmt->errno)

--- a/addFriend.php
+++ b/addFriend.php
@@ -53,8 +53,8 @@ if ($stmt->errno)
   die("Error during the execution of the SQL query - 1");
 
 //add friend's new symkey
-$stmt = $conn->prepare("INSERT INTO friendrequests (user1, user2, symkey) VALUES (?, ?, ?)");
-$stmt->bind_param("iis", $friendId, $userId, $_POST['symkeyforfriend']);
+$stmt = $conn->prepare("INSERT INTO friendrequests (useridTO, useridFROM, usernameFROM, symkey) VALUES (?, ?, ?, ?)");
+$stmt->bind_param("iiss", $friendId, $userId, $_POST['username'], $_POST['symkeyforfriend']);
 $stmt->execute();
 if ($stmt->errno)
   die("Error during the execution of the SQL query - 2");

--- a/database_setup.sql
+++ b/database_setup.sql
@@ -46,6 +46,7 @@ CREATE TABLE `friendrequests` (
   `useridTO` int(11) NOT NULL,
   `useridFROM` int(11) NOT NULL,
   `usernameFROM` varchar(80) COLLATE latin2_hungarian_ci NOT NULL,
+  `rejected` bit NOT NULL DEFAULT 0,
   `symkey` text COLLATE latin2_hungarian_ci NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin2 COLLATE=latin2_hungarian_ci;
 
@@ -63,6 +64,20 @@ CREATE TABLE `messages` (
   `messages` text COLLATE latin2_hungarian_ci NOT NULL,
   `nonce` binary(16) NOT NULL,
   `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=latin2 COLLATE=latin2_hungarian_ci;
+
+-- --------------------------------------------------------
+--
+-- Table structure for table `symkeyrequests`
+--
+
+DROP TABLE IF EXISTS `symkeyrequests`;
+CREATE TABLE `symkeyrequests` (
+  `id` int(11) NOT NULL,
+  `useridTO` int(11) NOT NULL,
+  `useridFROM` int(11) NOT NULL,
+  `usernameFROM` varchar(80) COLLATE latin2_hungarian_ci NOT NULL,
+  `symkey` text COLLATE latin2_hungarian_ci NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin2 COLLATE=latin2_hungarian_ci;
 
 -- --------------------------------------------------------
@@ -115,6 +130,12 @@ ALTER TABLE `friendrequests`
   ADD PRIMARY KEY (`id`);
 
 --
+-- Indexes for table `symkeyrequests`
+--
+ALTER TABLE `symkeyrequests`
+  ADD PRIMARY KEY (`id`);
+
+--
 -- Indexes for table `messages`
 --
 ALTER TABLE `messages`
@@ -142,6 +163,11 @@ ALTER TABLE `unverified_users`
 -- AUTO_INCREMENT for table `friendrequests`
 --
 ALTER TABLE `friendrequests`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+--
+-- AUTO_INCREMENT for table `symkeyrequests`
+--
+ALTER TABLE `symkeyrequests`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 --
 -- AUTO_INCREMENT for table `messages`

--- a/database_setup.sql
+++ b/database_setup.sql
@@ -43,8 +43,9 @@ USE `postq`;
 DROP TABLE IF EXISTS `friendrequests`;
 CREATE TABLE `friendrequests` (
   `id` int(11) NOT NULL,
-  `user1` int(11) NOT NULL,
-  `user2` int(11) NOT NULL,
+  `useridTO` int(11) NOT NULL,
+  `useridFROM` int(11) NOT NULL,
+  `usernameFROM` varchar(80) COLLATE latin2_hungarian_ci NOT NULL,
   `symkey` text COLLATE latin2_hungarian_ci NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin2 COLLATE=latin2_hungarian_ci;
 

--- a/getFriendList.js
+++ b/getFriendList.js
@@ -20,6 +20,7 @@ function generateMenu() {
     $('#menu').empty();
     //add AddFriend button to the top
     $('#menu').append('<li id="menuAddnewfriend" class="active"><a href="javascript:showAddNewFriend()"><span class="glyphicon glyphicon-plus"></span> New friend</a></li>');
+    $('#menu').append('<li id="menuFriendRequests"><a href="javascript:showFriendRequests()"><span class="glyphicon glyphicon-edit"></span> Friend requests</a></li>');
     friends = $.csv.toArrays(data);
     for(var i = 0; i < friends.length; i++) {
       $('#menu').append('<li id="menuMsgs' + friends[i][1] + '"><a href="javascript:showMessages(\'' + friends[i][0] + '\',\'' + friends[i][1] + '\',\'' + friends[i][2] + '\')"><span class="glyphicon glyphicon-user"></span> ' + friends[i][0] + '</a></li>');

--- a/getNewRequests.php
+++ b/getNewRequests.php
@@ -22,15 +22,15 @@ if(!(substr(loginhelper($conn, $_POST['username'], $_POST['password']),0,1) === 
   die("Authentication failed");
   
 // prepare, bind and execute
-$stmt = $conn->prepare("SELECT friendrequests.user1, friendrequests.user2, friendrequests.symkey FROM friendrequests, users WHERE friendrequests.user1 = users.id AND users.username = ?");
+$stmt = $conn->prepare("SELECT friendrequests.useridTO, friendrequests.useridFROM, friendrequests.usernameFROM, friendrequests.symkey FROM friendrequests, users WHERE friendrequests.useridTO = users.id AND users.username = ?");
 $stmt->bind_param("s", $_POST['username']);
 $stmt->execute();
 if ($stmt->errno)
   die("Error during the execution of the SQL query");
 
 //get the result
-$stmt->bind_result($user1, $user2, $symkey);
+$stmt->bind_result($useridTO, $useridFROM, $usernameFROM, $symkey);
 
 while($stmt->fetch())
-  echo $user1 . "," . $user2 . "," . $symkey . "\n";
+  echo $useridTO . "," . $useridFROM . "," . $usernameFROM . "," . $symkey . "\n"; //Problem if usernames allow comma!!! Add verification!
 ?>

--- a/getNewRequests.php
+++ b/getNewRequests.php
@@ -22,7 +22,7 @@ if(!(substr(loginhelper($conn, $_POST['username'], $_POST['password']),0,1) === 
   die("Authentication failed");
   
 // prepare, bind and execute
-$stmt = $conn->prepare("SELECT friendrequests.useridTO, friendrequests.useridFROM, friendrequests.usernameFROM, friendrequests.symkey FROM friendrequests, users WHERE friendrequests.useridTO = users.id AND users.username = ?");
+$stmt = $conn->prepare("SELECT friendrequests.useridTO, friendrequests.useridFROM, friendrequests.usernameFROM, friendrequests.symkey FROM friendrequests, users WHERE friendrequests.useridTO = users.id AND users.username = ? AND friendrequests.rejected = 0 ORDER BY friendrequests.id DESC");
 $stmt->bind_param("s", $_POST['username']);
 $stmt->execute();
 if ($stmt->errno)

--- a/getSymkeyRequests.php
+++ b/getSymkeyRequests.php
@@ -1,0 +1,29 @@
+<?php
+
+//Usage: getSymkeyRequests.php
+//    username=email@adfs.hu
+//    password=iExmLmGEgXVDPfGjI%2Fk5Iw%3D%3D
+
+require_once("helpers.php");
+require_once("sqlconnect.php");
+
+if(!$_POST['username'] || !$_POST['password'])
+  die("Error - one of the parameters is not set.");
+
+//check password
+if(!(substr(loginhelper($conn, $_POST['username'], $_POST['password']),0,1) === "1")) //loginhelper() needs to return with 1... for successfull login
+  die("Authentication failed");
+
+// prepare, bind and execute
+$stmt = $conn->prepare("SELECT sk.useridTO, sk.useridFROM, sk.usernameFROM, sk.symkey FROM symkeyrequests AS sk, users WHERE sk.useridTO = users.id AND users.username = ? ORDER BY sk.id DESC");
+$stmt->bind_param("s", $_POST['username']);
+$stmt->execute();
+if($stmt->errno)
+  die("Error during the execution of the SQL query");
+
+//get the result
+$stmt->bind_result($useridTO, $useridFROM, $usernameFROM, $symkey);
+
+while($stmt->fetch())
+  echo $useridTO . "," . $useridFROM . "," . $usernameFROM . "," . $symkey . "\n"; //Problem if usernames allow comma!!! Add verification!
+?>

--- a/handleFriendRequests.js
+++ b/handleFriendRequests.js
@@ -11,19 +11,41 @@
  */
 
 var requests;
+var symkeyrequests;
 
 function handleFriendRequests() {
+
+  //get requests to change symkeys
+  $.post("getSymkeyRequests.php", { username: inputEmail, password: authenticationkey } ,
+    function(data, status){
+      symkeyrequests = $.csv.toArrays(data);
+      $('#symkeyrequestsouter').empty(); //clear previous requests
+      if(symkeyrequests.length > 0){
+        $('#symkeyrequestsouter').append('<span class="glyphicon glyphicon-info-sign" title="Accepting new secret code will delete all previous message you sent!"></span>&nbsp;&nbsp;Secret code changing request from:<br/>');
+      }
+      for(var i = 0; i < symkeyrequests.length; i++) {
+        $('#symkeyrequestsouter').append('<div> \
+           <a href="javascript:acceptSymkeyRequest(' + i.toString() + ')"> <span class="glyphicon glyphicon-ok" title="Delete all my messages and accept new secret code"></span></a>&nbsp;&nbsp;' +
+           symkeyrequests[i][2] +  '</div>');
+      }
+      if(symkeyrequests.length > 0){
+        $('#symkeyrequestsouter').append('<hr/>');
+      }
+    }
+  );
 
   //get new requests - user1,user2,symkey
   $.post("getNewRequests.php", { username: inputEmail, password: authenticationkey } ,
   function(data, status){
     requests = $.csv.toArrays(data);
     $('#friendrequestsouter').empty(); //clear previous requests
-
+    if (requests.length > 0 ){
+      $('#friendrequestsouter').append('Friend request from:<br/>');
+    }
     for(var i = 0; i < requests.length; i++) {
       $('#friendrequestsouter').append('<div> \
-         <a href="javascript:acceptRequest(' + i.toString() + ')"> <span class="glyphicon glyphicon-ok"></span></a> \
-         <a href="javascript:rejectRequest(' + i.toString() + ')"> <span class="glyphicon glyphicon-remove"></span></a> ' +
+         <a href="javascript:acceptRequest(' + i.toString() + ')"> <span class="glyphicon glyphicon-ok"></span></a>&nbsp;&nbsp; \
+         <a href="javascript:rejectRequest(' + i.toString() + ')"> <span class="glyphicon glyphicon-remove"></span></a> &nbsp;&nbsp;' +
          requests[i][2] +  '</div>');
     }
   });
@@ -56,6 +78,26 @@ function rejectRequest(requestID) {
     function(data, status){
       if(data == "1") { //success
         displayAlert("#alertFriendRequests","success","Friend request rejected!");
+        generateMenu();
+        handleFriendRequests();
+      } else {
+        displayAlert("#alertFriendRequests","danger",data);
+      }
+    }
+  );
+}
+
+function acceptSymkeyRequest(requestID) {
+  var i = parseInt(requestID);
+  //NTRU decrypt
+  var plainSymKey = NTRUDecapsulate(symkeyrequests[i][3], privatekey);
+  //AES encrypt the symkey
+  var AESSymKey = AESencryptCBC_arr(plainSymKey, decryptionkey);
+  //send the symkey back, delete the requests
+  $.post("acceptChangeSymkey.php", { username: inputEmail, password: authenticationkey, friendId: symkeyrequests[i][1], symkeyforme: AESSymKey },
+    function(data, status){
+      if(data == "1") { //success
+        displayAlert("#alertFriendRequests","success","New secret shared!");
         generateMenu();
         handleFriendRequests();
       } else {

--- a/index.html
+++ b/index.html
@@ -113,6 +113,7 @@
       <div class="container-fluid" id="friendRequests">
         <br>
         <div id="alertFriendRequests" class="alertNewFriend"></div>
+        <div id="symkeyrequestsouter"></div>
         <div id="friendrequestsouter"></div>
       </div> <!-- friendRequests -->
 

--- a/index.html
+++ b/index.html
@@ -110,6 +110,11 @@
         <input type="email" id="inputFriendEmail" class="form-control" placeholder="Friend's username" required value="">
         <button class="btn btn-lg btn-success btn-block" onclick="addFriend()">Add friend</button>
       </div> <!-- addnewfriend -->
+      <div class="container-fluid" id="friendRequests">
+        <br>
+        <div id="alertFriendRequests" class="alertNewFriend"></div>
+        <div id="friendrequestsouter"></div>
+      </div> <!-- friendRequests -->
 
 <div id="videobox" style="display: none;">
     <video id="localVideo" playsinline autoplay muted></video>

--- a/initChangeSymkey.php
+++ b/initChangeSymkey.php
@@ -1,0 +1,76 @@
+<?php
+
+//Usage: initChangeSymkey.php
+//   username=email@adfs.hu
+//   password=iExmLmGEgXVDPfGjI%2Fk5Iw%3D%3D
+//   friend=test@test.com
+//   symkeyforme=iExmLmGEgXVDPfGjI%2Fk5Iw%3D%3D
+//   symkeyforfriend=iExmLmGEgXVDPfGjI%2Fk5Iw%3D%3D
+
+require_once("helpers.php");
+require_once("sqlconnect.php");
+
+if(!$_POST['username'] || !$_POST['password'] || !$_POST['friend'] || !$_POST['symkeyforme'] || !$_POST['symkeyforfriend'])
+  die("Error - one of the parameters is not set.");
+
+if($_POST['username'] === $_POST['friend'])
+  die("Error - you can not create keys to yourself.");
+
+//check password
+if(!(substr(loginhelper($conn, $_POST['username'], $_POST['password']),0,1) === "1")) //loginhelper() needs to return with 1... for successfull login
+  die("Error - authentication failed");
+
+//check if friend exists
+$userexists = userExists($conn, $_POST['friend']);
+if($userexists === False)
+  die("Error - choosen friend does not exists");
+if(substr($userexists,0,5) === "Error") 
+  die($userexists);
+
+//get user IDs
+$userId = getUserId($conn, $_POST['username']);
+$friendId = getUserId($conn, $_POST['friend']);
+
+//check if there is a symkey request from other user OR user already requested simkey but not accepted OR user requested friendship but not yet accepted
+//(these conditions could mess the negotiation)
+$stmt = $conn->prepare("SELECT (SELECT count(*) FROM symkeyrequests WHERE (useridTO = ? AND useridFROM = ?) OR (useridTO = ? AND useridFROM = ?)) + (SELECT COUNT(*) FROM friendrequests WHERE useridFROM = ? AND useridTO = ?) AS total");
+$stmt->bind_param("iiiiii",$userId, $friendId, $friendId, $userId, $userId, $friendId);
+$stmt->execute();
+if($stmt->errno)
+  die("Error during the execution of the SQL query - 5");
+$stmt->bind_result($num_requests);
+if($stmt->fetch()){ //get results
+  if ($num_requests !== 0){
+    die("Error - There is a secret code negotiation pending... Waiting acceptance. " );
+  }
+} else {
+  die("Error - during the execution of the SQL query - 4" );
+}
+$stmt->close();
+
+//delete older messages (they are encrypted with old symkey and could not be decrypted again)
+$stmt = $conn->prepare("DELETE FROM messages WHERE user1 = ? AND user2 = ?");
+$stmt->bind_param("ii", $userId, $friendId);
+$stmt->execute();
+if($stmt->errno)
+  die("Error during the execution of the SQL query - 3");
+
+//add my new symkey
+$stmt = $conn->prepare("UPDATE symkeys SET symkey = ? WHERE user1 = ? AND user2  = ?");
+$stmt->bind_param("sii", $_POST['symkeyforme'], $userId, $friendId);
+$stmt->execute();
+if($stmt->errno)
+  die("Error during the execution of the SQL query - 2");
+
+//add friend's new symkey
+$stmt = $conn->prepare("INSERT INTO symkeyrequests (useridTO, useridFROM, usernameFROM, symkey) VALUES (?, ?, ?, ?)");
+$stmt->bind_param("iiss", $friendId, $userId, $_POST['username'], $_POST['symkeyforfriend']);
+$stmt->execute();
+if($stmt->errno)
+  die("Error during the execution of the SQL query - 1");
+
+echo "1";
+
+$stmt->close();
+$conn->close();
+?>

--- a/postq.js
+++ b/postq.js
@@ -19,9 +19,12 @@ function pageLoaded() {
   }
 }
 
-function send() {
+function send(text) {
   msgId++;
   var msg = $('#newmsg').val();
+  if(typeof text === 'string')
+    msg=text;
+
   var msgWithId = msgId.toString() + ";" + msg;
   $('#newmsg').val(''); //cleare the message box
   

--- a/rejectRequest.php
+++ b/rejectRequest.php
@@ -1,0 +1,38 @@
+<?php
+ 
+//Usage: rejectRequest.php
+//    username=test@test.com
+//    password=iExmLmGEgXVDPfGjI/k5Iw==
+//    friendId=5
+
+require_once("helpers.php");
+require_once("sqlconnect.php");
+if(!$_POST['username'] || !$_POST['password'] || !$_POST['friendId'])
+  die("Error - one of the parameters is not set.");
+
+//check password
+if(!(substr(loginhelper($conn, $_POST['username'], $_POST['password']),0,1) === "1")) //loginhelper() needs to return with 1... for successfull login
+  die("Authentication failed");
+
+$userId = getUserId($conn, $_POST['username']);
+//delete request
+$stmt = $conn->prepare("DELETE FROM friendrequests WHERE useridTO = ? AND useridFROM = ?");
+$stmt->bind_param("ii", $userId, $_POST['friendId']);
+$stmt->execute();
+if ($stmt->errno)
+  die("Error during the execution of the SQL query - 3");
+
+if($conn->affected_rows !== 1)
+  die("Error - not existing friend requests");
+
+$stmt = $conn->prepare("DELETE FROM symkeys WHERE user1 = ? AND user2 = ?");
+$stmt->bind_param("ii", $_POST['friendId'], $userId);
+$stmt->execute();
+if ($stmt->errno)
+  die("Error during the execution of the SQL query - 3");
+
+echo "1";
+
+$stmt->close();
+$conn->close();
+?>

--- a/rejectRequest.php
+++ b/rejectRequest.php
@@ -16,7 +16,7 @@ if(!(substr(loginhelper($conn, $_POST['username'], $_POST['password']),0,1) === 
 
 $userId = getUserId($conn, $_POST['username']);
 //delete request
-$stmt = $conn->prepare("DELETE FROM friendrequests WHERE useridTO = ? AND useridFROM = ?");
+$stmt = $conn->prepare("UPDATE friendrequests SET rejected = 1 WHERE useridTO = ? AND useridFROM = ?");
 $stmt->bind_param("ii", $userId, $_POST['friendId']);
 $stmt->execute();
 if ($stmt->errno)
@@ -24,12 +24,6 @@ if ($stmt->errno)
 
 if($conn->affected_rows !== 1)
   die("Error - not existing friend requests");
-
-$stmt = $conn->prepare("DELETE FROM symkeys WHERE user1 = ? AND user2 = ?");
-$stmt->bind_param("ii", $_POST['friendId'], $userId);
-$stmt->execute();
-if ($stmt->errno)
-  die("Error during the execution of the SQL query - 3");
 
 echo "1";
 

--- a/show.js
+++ b/show.js
@@ -37,6 +37,7 @@ var messageUpdateTimer;
 var messageTimeout = 5; //in second
 var msgId;
 var msgIduser2;
+const warnSymkeyExchangeEvery = 20 //messages
 
 function showMessages(username, userid, symkey) {
   clearTimeout(messageUpdateTimer); //otherwise problem with switching between chats
@@ -60,10 +61,13 @@ function showMessages(username, userid, symkey) {
         var msgNonce = messages[i].substring(1, messages[i].indexOf(";"));
         var idAndMsg = messages[i].substring(messages[i].indexOf(";")+1);
         var decIdAndMsg = AESdecryptCTR(idAndMsg, msgSymKey, msgNonce);
+        if(decIdAndMsg.indexOf(";") == -1) //error decoding or outdated symkey
+          continue;
         var decIdAndMsgA = decIdAndMsg.split(";");
         var msg = decIdAndMsgA[1];
         var msgIdi = parseInt(decIdAndMsgA[0]);
-
+        if(msgIdi == 00 && decIdAndMsgA[0].length != 1) //error decoding or outdated symkey
+          continue;
         if(fromTo == '1' && msgIdi > msgId) {
           msgId = msgIdi;
           $('#messages').append('<div class="msgFromMe">' + msg + '</div>');
@@ -79,6 +83,8 @@ function showMessages(username, userid, symkey) {
           }
 
         }
+        if(i != 0 && i % warnSymkeyExchangeEvery == 0)
+          $('#messages').append('<div>Reminder: Consider to change secret code.</div>');
       }
     }
     //if call params were recieved
@@ -94,12 +100,42 @@ function showMessages(username, userid, symkey) {
 
     $('#addnewfriend').hide();
     $('#friendRequests').hide();
-    $('.msgtitle').text(username);
+    $('.msgtitle').html(username + ' <a href="javascript:changeSymkey(\'' + username + '\', ' + userid + ')"><span class="glyphicon glyphicon-flash" title="Delete all my messages and enforce new secret code"></span></a>');
     $('#messagesouter').show();
     $('#messages').scrollTo("max");
     markSelected("menuMsgs"+userid);
     messageUpdateTimer = setTimeout(function(){showMessages(username, userid, symkey);}, messageTimeout*1000);
   });
+}
+
+function changeSymkey(username, userid) {
+
+  $.post("getPublicKey.php", { user: username },
+    function(data, status){
+      if(data.startsWith("Error")) {
+        displayAlert("#alertMessages","danger","Change symkey failed. " + data);
+      } else { //no error
+        var publicKeyOfFriend = data;
+        var encaps = NTRUEncapsulate(publicKeyOfFriend);
+        var plainkey = encaps[0];
+        var symkeyforfriend = encaps[1];
+        var symkeyforme = AESencryptCBC_arr(plainkey, decryptionkey);
+
+        $.post("initChangeSymkey.php", {username: inputEmail, password: authenticationkey, friend: username, symkeyforme: symkeyforme, symkeyforfriend: symkeyforfriend},
+          function(data, status){
+            if(data == "1") { //success
+              send('I changed secret code. All my previous messages were discarded. Please accept a new generated new secret in "Friend requests" to continue conversation. If you send further messages they can not be read by me.');
+              displayAlert("#alertMessages","success","Symmetric key changed successfully!");
+              showMessages(username, userid, symkeyforme)
+            } else {
+              displayAlert("#alertMessages","danger",data);
+            }
+            generateMenu();
+          }
+        );
+      }
+    }
+  );
 }
 
 function markSelected(id) {

--- a/show.js
+++ b/show.js
@@ -13,9 +13,22 @@
 function showAddNewFriend() {
   clearTimeout(messageUpdateTimer);
   $('#messagesouter').hide();
+  $('#friendRequests').hide();
+  $('#alertNewFriend').empty();
   $('.msgtitle').text('Add new friend');
   $('#addnewfriend').show();
   markSelected("menuAddnewfriend");
+}
+
+function showFriendRequests() {
+  clearTimeout(messageUpdateTimer);
+  $('#messagesouter').hide();
+  $('#addnewfriend').hide();
+  $('.msgtitle').text('Manage friend requests');
+  $('#alertFriendRequests').empty();
+  $('#friendRequests').show();
+  markSelected("menuFriendRequests");
+  handleFriendRequests()
 }
 
 var user2Id;
@@ -80,6 +93,7 @@ function showMessages(username, userid, symkey) {
     }
 
     $('#addnewfriend').hide();
+    $('#friendRequests').hide();
     $('.msgtitle').text(username);
     $('#messagesouter').show();
     $('#messages').scrollTo("max");

--- a/signin.js
+++ b/signin.js
@@ -46,7 +46,6 @@ function signin_from_localStorage(){
         $('#signin').hide();
         $('#main').show();
         privatekey = AESdecryptCBC_txt(data.substr(1), decryptionkey); //login.php returns '1'.privatekey_aes
-        handleFriendRequests();
         generateMenu();
       } else {
         displayLoginAlert("danger",data);
@@ -79,7 +78,6 @@ function signin() {
       displayLoginAlert("danger","Calculating the scrypt hash of the password failed. Try again. Detailed error: " + error.toString());
     } else if (hash) {
       decryptionkey = hash.slice(0,16);
-
       authenticationkey = btoa(String.fromCharCode.apply(null,hash.slice(16,32)));
       $.post("login.php", {	username: inputEmail,	password: authenticationkey },
 
@@ -88,7 +86,7 @@ function signin() {
             $('#signin').hide();
             $('#main').show();
             privatekey = AESdecryptCBC_txt(data.substr(1), decryptionkey); //login.php returns '1'.privatekey_aes
-            handleFriendRequests();
+
             generateMenu();
             if ($('#rememberMe').is(":checked")) { //Option to remeber user saving keys
               localStorage.setItem('local_username',inputEmail);


### PR DESCRIPTION
Hi Mark, me again!

This PR is adding two important features:
1) Users can choose either to accept or to reject a friend request.
When user accept it, encrypted symkey is stored in table "simkeys" and new entry is shown in menu. If user reject, the "friendrequests" row is updated with value reject. This request will never be show again and the requester will not be notified about that (eternal pending request).
2) Users can request to change secret code for a conversation.
When user decides it, an automatic message will be sent to notify friend about the situation. All previous messages from requester are deleted from database (no need to store them since old symkey will not be kept). A new symkey is generated and inserted into table "symkeyrequests", and also updated in "symkeys". The friend still can see their messages and will receive a request to change secret code. When friend accept it, all their messages will also be deleted, entry in  "symkeyrequests" is deleted and record in "symkeys" is updated. To request a new symkey it is checked if there is any pending request for symkey change or friend request. There is an option to remind user to change symkey to avoid many messages stored in server (default 20 messages).

I think this PR can solve feature request to change symkeys every N messages or by time!



